### PR TITLE
Support Node 4

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,10 @@
 module.exports = {
   extends: "eslint:recommended",
-  plugins: ["prettier"],
+  plugins: ["node", "prettier"],
   parserOptions: { ecmaVersion: 2015, sourceType: "script" },
   env: { es6: true, node: true },
-  rules: { "prettier/prettier": "error" }
+  rules: {
+    "prettier/prettier": "error",
+    "node/no-unsupported-features": "error"
+  }
 };

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { run } = require("./");
+const run = require("./").run;
 
 const result = run(process.argv.slice(2));
 

--- a/examples/acorn.js
+++ b/examples/acorn.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const acorn = require("acorn");
 const testParser = require("./parser");
 

--- a/examples/babel.js
+++ b/examples/babel.js
@@ -1,11 +1,13 @@
+"use strict";
+
 const babelGenerate = require("babel-generator");
 const babylon = require("babylon");
 const testGenerator = require("./generator");
 const random = require("../random");
 
-function generate(code, { sourceType, options }) {
-  const ast = babylon.parse(code, { sourceType });
-  return babelGenerate.default(ast, options, code);
+function generate(code, options) {
+  const ast = babylon.parse(code, { sourceType: options.sourceType });
+  return babelGenerate.default(ast, options.options, code);
 }
 
 function generateRandomOptions() {

--- a/examples/babylon.js
+++ b/examples/babylon.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const babylon = require("babylon");
 const testParser = require("./parser");
 

--- a/examples/escodegen.js
+++ b/examples/escodegen.js
@@ -1,11 +1,16 @@
+"use strict";
+
 const escodegen = require("escodegen");
 const esprima = require("esprima");
 const testGenerator = require("./generator");
 const random = require("../random");
 
-function generate(code, { sourceType, options }) {
-  const ast = esprima.parse(code, { sourceType, comments: true });
-  return escodegen.generate(ast, options);
+function generate(code, options) {
+  const ast = esprima.parse(code, {
+    sourceType: options.sourceType,
+    comments: true
+  });
+  return escodegen.generate(ast, options.options);
 }
 
 function generateRandomOptions() {

--- a/examples/espree.js
+++ b/examples/espree.js
@@ -1,8 +1,10 @@
+"use strict";
+
 const espree = require("espree");
 const testParser = require("./parser");
 
-function parse(code, { sourceType }) {
-  return espree.parse(code, { sourceType, ecmaVersion: 7 });
+function parse(code, options) {
+  return espree.parse(code, { sourceType: options.sourceType, ecmaVersion: 7 });
 }
 
 module.exports = testParser(parse);

--- a/examples/esprima.js
+++ b/examples/esprima.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const esprima = require("esprima");
 const testParser = require("./parser");
 

--- a/examples/flow.js
+++ b/examples/flow.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const flow = require("flow-parser");
 const testParser = require("./parser");
 
@@ -7,8 +9,9 @@ function parse(code) {
   if (ast.errors.length > 0) {
     const message = ast.errors
       .map(
-        ({ message, loc: { start } }) =>
-          `${message} (${start.line}:${start.column})`
+        messageInfo =>
+          `${messageInfo.message} (${messageInfo.loc.start.line}:${messageInfo
+            .loc.start.column})`
       )
       .join("\n");
     const error = new SyntaxError(message);

--- a/examples/generator.js
+++ b/examples/generator.js
@@ -1,14 +1,15 @@
+"use strict";
+
 const expect = require("unexpected");
 
-module.exports = (generate, generateRandomOptions) => ({
-  code,
-  sourceType,
-  reproductionData = null
-}) => {
+module.exports = (generate, generateRandomOptions) => generatorOptions => {
+  const code = generatorOptions.code;
+  const sourceType = generatorOptions.sourceType;
+  const reproductionData = generatorOptions.reproductionData || null;
   const isReproduction = reproductionData !== null;
-  const {
-    options = generateRandomOptions({ sourceType })
-  } = reproductionData || {};
+  const options = reproductionData
+    ? reproductionData.options
+    : generateRandomOptions({ sourceType });
   const generateData = { sourceType, options };
   const artifacts = {};
 

--- a/examples/parser.js
+++ b/examples/parser.js
@@ -1,14 +1,20 @@
+"use strict";
+
 const expect = require("unexpected");
 
-module.exports = (parse, getType = null) => ({ code, sourceType }) => {
+module.exports = (parse, getType) => generatorOptions => {
   let ast;
   try {
-    ast = parse(code, { sourceType });
+    ast = parse(generatorOptions.code, {
+      sourceType: generatorOptions.sourceType
+    });
   } catch (error) {
     return { error };
   }
 
-  const type = getType ? getType({ sourceType }) : "Program";
+  const type = getType
+    ? getType({ sourceType: generatorOptions.sourceType })
+    : "Program";
 
   try {
     expect(ast, "to have own property", "type", type);

--- a/examples/prettier.js
+++ b/examples/prettier.js
@@ -1,16 +1,20 @@
+"use strict";
+
 const prettier = require("prettier");
 const testGenerator = require("./generator");
 const random = require("../random");
 
-function generate(code, { options }) {
-  return prettier.format(code, options);
+function generate(code, generatorOptions) {
+  return prettier.format(code, generatorOptions.options);
 }
 
-function generateRandomOptions({ sourceType }) {
+function generateRandomOptions(options) {
   return {
     bracketSpacing: random.bool(),
     jsxBracketSameLine: random.bool(),
-    parser: sourceType === "module" ? random.item(["babylon", "flow"]) : "flow",
+    parser: options.sourceType === "module"
+      ? random.item(["babylon", "flow"])
+      : "flow",
     printWidth: random.int(200),
     semi: random.bool(),
     singleQuote: random.bool(),

--- a/examples/shift-codegen.js
+++ b/examples/shift-codegen.js
@@ -1,13 +1,17 @@
+"use strict";
+
 const shiftCodegen = require("shift-codegen");
-const { parseModule, parseScript } = require("shift-parser");
+const shiftParser = require("shift-parser");
 const testGenerator = require("./generator");
 const random = require("../random");
 
-function generate(code, { sourceType, options }) {
-  const parseFunction = sourceType === "module" ? parseModule : parseScript;
+function generate(code, generatorOptions) {
+  const parseFunction = generatorOptions.sourceType === "module"
+    ? shiftParser.parseModule
+    : shiftParser.parseScript;
   const ast = parseFunction(code, { earlyErrors: false });
 
-  const generator = options.minimal
+  const generator = generatorOptions.options.minimal
     ? shiftCodegen.MinimalCodeGen
     : shiftCodegen.FormattedCodeGen;
 

--- a/examples/shift-parser.js
+++ b/examples/shift-parser.js
@@ -1,13 +1,17 @@
-const { parseModule, parseScript } = require("shift-parser");
+"use strict";
+
+const shiftParser = require("shift-parser");
 const testParser = require("./parser");
 
-function parse(code, { sourceType }) {
-  const parseFunction = sourceType === "module" ? parseModule : parseScript;
+function parse(code, generatorOptions) {
+  const parseFunction = generatorOptions.sourceType === "module"
+    ? shiftParser.parseModule
+    : shiftParser.parseScript;
   return parseFunction(code, { earlyErrors: false });
 }
 
-function getType({ sourceType }) {
-  return sourceType === "module" ? "Module" : "Script";
+function getType(generatorOptions) {
+  return generatorOptions.sourceType === "module" ? "Module" : "Script";
 }
 
 module.exports = testParser(parse, getType);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babylon": "^6.17.1",
     "escodegen": "^1.8.1",
     "eslint": "^3.19.0",
+    "eslint-plugin-node": "^5.0.0",
     "eslint-plugin-prettier": "^2.1.1",
     "espree": "^3.4.3",
     "esprima": "^3.1.3",

--- a/random.js
+++ b/random.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const randomInt = require("random-int");
 const randomItem = require("random-item");
 
@@ -41,7 +43,7 @@ const lineTerminators = [
 ];
 
 function randomArray(length, randomItem) {
-  return [...Array(length)].map(() => randomItem());
+  return Array.from(Array(length)).map(() => randomItem());
 }
 
 function randomString(length, randomChar) {
@@ -63,9 +65,9 @@ function randomSingleLineComment() {
   return `//${contents}${newline}`;
 }
 
-function randomMultiLineComment({ allowNewlines = false } = {}) {
+function randomMultiLineComment(options) {
   const chars = whitespace.concat(
-    allowNewlines ? lineTerminators : [],
+    options && options.allowNewlines ? lineTerminators : [],
     letters
   );
   const contents = randomString(randomInt(20), () => randomItem(chars));
@@ -81,11 +83,9 @@ const insertCommentsChoicesWithNewlines = [
   () => randomMultiLineComment({ allowNewlines: true })
 ];
 
-function insertComments(
-  whitespaceString,
-  { times = 1, allowNewlines = false } = {}
-) {
-  const choices = allowNewlines
+function insertComments(whitespaceString, options) {
+  const times = options && options.times === undefined ? 1 : options.times;
+  const choices = options && options.allowNewlines
     ? insertCommentsChoicesWithNewlines
     : insertCommentsChoices;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,6 +399,15 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-node@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.0.0.tgz#948b1fb82e3f0a744e86fad19aa4f49537d246cc"
+  dependencies:
+    ignore "^3.3.3"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
+    semver "5.3.0"
+
 eslint-plugin-prettier@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.1.tgz#2fb7e2ab961f2b61d2c8cf91bc17716ca8c53868"
@@ -616,7 +625,7 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-ignore@^3.2.0:
+ignore@^3.2.0, ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -802,7 +811,7 @@ magicpen@5.12.0:
     color-diff "0.1.7"
     supports-color "1.2.0"
 
-minimatch@^3.0.2:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -999,7 +1008,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.6:
+resolve@^1.1.6, resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -1031,6 +1040,10 @@ rx-lite@^3.1.2:
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+semver@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 shelljs@^0.7.5:
   version "0.7.7"


### PR DESCRIPTION
Hello :wave:

This removes the syntax/runtime objects that are unavailable in Node 4 from the codebase. It also adds `eslint-plugin-node` to ensure that all syntax is supported on Node 4.

I wasn't sure whether you preferred having a build step and keeping the syntax modern, or avoiding a build step and not using things like destructuring. In either case, some modification to the code would be necessary, because there is one place where the code used `Proxy`, which isn't possible to transpile.

(refs https://github.com/eslint/eslint/pull/8422)