### PR TITLE
pin shift-codegen (fixes #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "optionator": "^0.8.2",
     "random-int": "^1.0.0",
     "random-item": "^1.0.0",
-    "shift-codegen": "^5.0.5",
+    "shift-codegen": "5.0.5",
     "shift-fuzzer": "^1.0.2",
     "shift-reducer": "^4.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,7 +982,7 @@ shift-ast@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/shift-ast/-/shift-ast-4.0.0.tgz#1d4152a2add28644a52aeb2e0c87d8925d3d97ff"
 
-shift-codegen@^5.0.5:
+shift-codegen@5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/shift-codegen/-/shift-codegen-5.0.5.tgz#f6bd7a2161c5a4ec9446659e13f1fdd143c5c9c1"
   dependencies:


### PR DESCRIPTION
Fixes #5.

I used just `yarn add --exact shift-codegen@5.0.5`.
Feel free to ignore this PR if you want to fix with the new `shift-codegen@5.1.0`. (I didn't it since I couldn't find unit tests)